### PR TITLE
When faking out manifestwork status set required val

### DIFF
--- a/controllers/addoncontroller_test.go
+++ b/controllers/addoncontroller_test.go
@@ -453,7 +453,6 @@ var _ = Describe("Addon Status Update Tests", func() {
 
 							return testK8sClient.Status().Update(testCtx, manifestWork)
 						}, timeout, interval).Should(Succeed())
-
 					})
 
 					It("Should set the ManagedClusterAddon status to unknown", func() {
@@ -582,6 +581,7 @@ func manifestWorkResourceStatusWithSubscriptionInstalledCSVFeedBack(installedCSV
 						},
 					},
 				},
+				Conditions: []metav1.Condition{},
 			},
 		},
 	}


### PR DESCRIPTION
- status.resourceStatus.manifests.conditions is required
  according to types file but is not required in crd
- Not sure how, but unit tests pass ok but not in sonar
  somehow (maybe on go client side?) in the sonar env
  it's catching that the conditions were not being set
  when faking out manifestwork status in unit tests
- This change fixes that, should work whether or not
  it's being strict about the required field.

Signed-off-by: Tesshu Flower <tflower@redhat.com>