### PR TITLE
Deploy acm-2.7 volsync with acm 2.7

### DIFF
--- a/controllers/addoncontroller.go
+++ b/controllers/addoncontroller.go
@@ -48,7 +48,7 @@ const (
 	// Defaults for ACM-2.6
 	DefaultCatalogSource          = "redhat-operators"
 	DefaultCatalogSourceNamespace = "openshift-marketplace"
-	DefaultChannel                = "acm-2.6"
+	DefaultChannel                = "acm-2.7"
 	DefaultStartingCSV            = "" // By default no starting CSV - will use the latest in the channel
 	DefaultInstallPlanApproval    = "Automatic"
 )


### PR DESCRIPTION
- Deploys the 0.6.x VolSync with ACM 2.7

Signed-off-by: Tesshu Flower <tflower@redhat.com>