### PR TITLE
Explicitly enable CGO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY controllers/ controllers/
 # Build
 # We don't vendor modules. Enforce that behavior
 ENV GOFLAGS=-mod=readonly
+ENV CGO_ENABLED=1
 ARG versionFromGit_arg="(unknown)"
 ARG commitFromGit_arg="(unknown)"
 RUN GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o controller -ldflags "-X main.versionFromGit=${versionFromGit_arg} -X main.commitFromGit=${commitFromGit_arg}" main.go


### PR DESCRIPTION
Previously CGO was not disabled, but we were relying on CGO being enabled by default - in future when we move to golang 1.20 there may be envs where CGO gets turned off at build time.

Ensure CGO is always enabled

Will cherry-pick this into release-2.5-2.8