### PR TITLE
[release-2.6] Upstream golang1.20 (#158)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the addon controller binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
 USER root
 
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ARCH := $(shell go env GOARCH)
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Helper software versions
-GOLANGCI_VERSION := v1.50.0
+GOLANGCI_VERSION := v1.54.2
 
 .PHONY: docker-build
 docker-build: test ## Build docker image

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/volsync-addon-controller
 
-go 1.19
+go 1.20
 
 require (
 	github.com/onsi/ginkgo/v2 v2.1.4


### PR DESCRIPTION
* update upstream to golang 1.20



* Update golangci-lint to v1.54.2



---------


(cherry picked from commit 66a4717651bbb9a58a7893368852cbcf2caeb3fa)