### PR TITLE
Update addon-framework to v0.9.3

### DIFF
--- a/controllers/addoncontroller.go
+++ b/controllers/addoncontroller.go
@@ -215,9 +215,9 @@ func (h *volsyncAgent) loadManifestFromFile(file string, cluster *clusterv1.Mana
 	manifestConfigValues := addonfactory.StructToValues(manifestConfig)
 
 	// Get values from addonDeploymentConfig
-	deploymentConfigValues, err := addonfactory.GetAddOnDeloymentConfigValues(
-		addonfactory.NewAddOnDeloymentConfigGetter(h.addonClient),
-		addonfactory.ToAddOnDeloymentConfigValues,
+	deploymentConfigValues, err := addonfactory.GetAddOnDeploymentConfigValues(
+		addonframeworkutils.NewAddOnDeploymentConfigGetter(h.addonClient),
+		addonfactory.ToAddOnDeploymentConfigValues,
 	)(cluster, addon)
 	if err != nil {
 		return nil, err

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -30,10 +30,9 @@ var cancel context.CancelFunc
 var testK8sClient client.Client
 
 const (
-	maxWait     = "60s"
-	timeout     = "10s"
-	fiveSeconds = "5s"
-	interval    = "1s"
+	maxWait  = "60s"
+	timeout  = "10s"
+	interval = "1s"
 )
 
 func TestControllers(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	k8s.io/client-go v0.29.2
 	k8s.io/component-base v0.29.1
 	k8s.io/klog/v2 v2.120.1
-	open-cluster-management.io/addon-framework v0.9.2
+	open-cluster-management.io/addon-framework v0.9.3
 	open-cluster-management.io/api v0.13.0
 	sigs.k8s.io/controller-runtime v0.17.2
 )

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 h1:aVUu9fTY98ivBPKR9Y5w/A
 k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
 k8s.io/utils v0.0.0-20240310230437-4693a0247e57 h1:gbqbevonBh57eILzModw6mrkbwM0gQBEuevE/AaBsHY=
 k8s.io/utils v0.0.0-20240310230437-4693a0247e57/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-open-cluster-management.io/addon-framework v0.9.2 h1:oQnk6Y6433Fvi/MC8sWoy68lHzkqPsFLj7IEx07kFfU=
-open-cluster-management.io/addon-framework v0.9.2/go.mod h1:LDkGLGTQh+sthF1qWlv87iMeAuRPsNEMK31O14kMneA=
+open-cluster-management.io/addon-framework v0.9.3 h1:ZD7to1+YkxwYzfoMBc+0rnKp6OMuUVaY9ky0fcyB8qI=
+open-cluster-management.io/addon-framework v0.9.3/go.mod h1:LDkGLGTQh+sthF1qWlv87iMeAuRPsNEMK31O14kMneA=
 open-cluster-management.io/api v0.13.0 h1:dlcJEZlNlE0DmSDctK2s7iWKg9l+Tgb0V78Z040nMuk=
 open-cluster-management.io/api v0.13.0/go.mod h1:CuCPEzXDvOyxBB0H1d1eSeajbHqaeGEKq9c63vQc63w=
 open-cluster-management.io/sdk-go v0.13.1-0.20240416030555-aa744f426379 h1:8jXVHfgy+wgXq1mrWC1mTieoP77WsAAHNpzILMIzWB0=


### PR DESCRIPTION

- updates to some function calls as older ones have been removed
- unit test updates needed as the underlying functions have slightly different implementations - one in particular required an external clustermanagementaddon controller to update status (this controller is part of OCM/ACM, see here:  https://github.com/open-cluster-management-io/ocm/blob/main/pkg/addon/controllers/cmainstallprogression/controller.go#L66).  Needed to fake out the status update for the unit tests to work properly as this controller is external to the ones started by the addon-framework (i.e. not part of volsync-addon-controller) and therefore not running during the unit tests.