### PR TITLE
fix(KONFLUX-3663): format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/volsync-addon-controller-acm-211-pull-request.yaml
+++ b/.tekton/volsync-addon-controller-acm-211-pull-request.yaml
@@ -339,7 +339,7 @@ spec:
               - "false"
       - name: sast-snyk-check
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           params:
             - name: name
@@ -357,6 +357,11 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
+        params:
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
       - name: clamav-scan
         params:
           - name: image-digest

--- a/.tekton/volsync-addon-controller-acm-211-push.yaml
+++ b/.tekton/volsync-addon-controller-acm-211-push.yaml
@@ -336,7 +336,7 @@ spec:
               - "false"
       - name: sast-snyk-check
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           params:
             - name: name
@@ -354,6 +354,11 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
+        params:
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
       - name: clamav-scan
         params:
           - name: image-digest


### PR DESCRIPTION
This update configures the SAST task to upload SARIF results to quay.io for
long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263