### PR TITLE
Use acm rh registry pull request secret for volsync-system - https://issues.redhat.com/browse/ACM-16311

### DIFF
--- a/controllers/addoncontroller.go
+++ b/controllers/addoncontroller.go
@@ -80,6 +80,13 @@ const (
 	AnnotationVolSyncAddonDeployTypeOverrideOLMValue = "olm"
 
 	AnnotationHelmChartKey = "helm-chart-key"
+
+	// This is the name of the pull secret that is copied to the namespace (volsync-system) on the managed
+	// cluster.  This will allow pulls to the redhat registry.
+	// (Other addons get this copied to open-cluster-management-agent-addon namespace on the mgd cluster)
+	// Note this secret is automatically copied to volsync-system via putting the
+	// label "addon.open-cluster-management.io/namespace":"true" on the volsync-system ns
+	RHRegistryPullSecretName = "open-cluster-management-image-pull-credentials"
 )
 
 func init() {
@@ -156,7 +163,6 @@ func (h *volsyncAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
 							Resource:  "deployments",
 							Name:      "volsync",
 							Namespace: "*",
-							//Namespace: "volsync-system",
 						},
 						ProbeRules: []workapiv1.FeedbackRule{
 							{

--- a/controllers/helmutils/helmutils_test.go
+++ b/controllers/helmutils/helmutils_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Helmutils", func() {
 			}
 
 			renderedObjs, err = helmutils.RenderManifestsFromChart(chart, testNamespace, testCluster, clusterIsOpenShift,
-				chartValues, genericCodec)
+				chartValues, genericCodec, controllers.RHRegistryPullSecretName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(renderedObjs).NotTo(BeNil())
 		})

--- a/controllers/helmutils/helmutilstest/testhelper.go
+++ b/controllers/helmutils/helmutilstest/testhelper.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+
+	"github.com/stolostron/volsync-addon-controller/controllers"
 )
 
 //nolint:funlen
@@ -130,6 +132,13 @@ func VerifyHelmRenderedVolSyncObjects(objs []runtime.Object,
 		Expect(deployment.Spec.Template.Spec.SecurityContext.RunAsUser).NotTo(BeNil())
 		Expect(*deployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(65534)))
 	}
+
+	// Check ServiceAccount
+	// It should have the pull secret set
+	Expect(len(serviceAccount.ImagePullSecrets)).To(Equal(1))
+	Expect(serviceAccount.ImagePullSecrets[0]).To(Equal(corev1.LocalObjectReference{
+		Name: controllers.RHRegistryPullSecretName,
+	}))
 
 	// Return the deployment (can be checked further by tests)
 	return deployment

--- a/controllers/manifesthelper_helmdeploy.go
+++ b/controllers/manifesthelper_helmdeploy.go
@@ -103,7 +103,7 @@ func (mh *manifestHelperHelmDeploy) loadManifestsFromHelmRepo(values addonfactor
 	}
 
 	return helmutils.RenderManifestsFromChart(chart, installNamespace,
-		mh.cluster, mh.clusterIsOpenShift, values, genericCodec)
+		mh.cluster, mh.clusterIsOpenShift, values, genericCodec, RHRegistryPullSecretName)
 }
 
 func (mh *manifestHelperHelmDeploy) getValuesForManifest() (addonfactory.Values, error) {

--- a/controllers/manifests/helm-chart/namespace.yaml
+++ b/controllers/manifests/helm-chart/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .InstallNamespace }}
+  labels:
+    "addon.open-cluster-management.io/namespace": "true"


### PR DESCRIPTION
Allows non-Openshift clusters to be able to access the images in the redhat registry in the volsync-system namespace

- Use ACM label that will copy the pull request secret to the volsync-system namespace (this is similar to other ACM addons)
- Update the volsync service account to use this pull request secret