### PR TITLE
image overrides for volsync in helmchart

### DIFF
--- a/.tekton/volsync-addon-controller-acm-213-pull-request.yaml
+++ b/.tekton/volsync-addon-controller-acm-213-pull-request.yaml
@@ -240,7 +240,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/volsync-addon-controller-acm-213-push.yaml
+++ b/.tekton/volsync-addon-controller-acm-213-push.yaml
@@ -237,7 +237,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
         - name: kind
           value: task
         resolver: bundles

--- a/controllers/addoncontroller.go
+++ b/controllers/addoncontroller.go
@@ -81,6 +81,9 @@ const (
 
 	AnnotationHelmChartKey = "helm-chart-key"
 
+	EnvVarVolSyncImageName   = "OPERAND_IMAGE_VOLSYNC"           // find permanent name for this
+	EnvVarRbacProxyImageName = "OPERAND_IMAGE_VOLSYNC_RBACPROXY" // find permanent name for this
+
 	// This is the name of the pull secret that is copied to the namespace (volsync-system) on the managed
 	// cluster.  This will allow pulls to the redhat registry.
 	// (Other addons get this copied to open-cluster-management-agent-addon namespace on the mgd cluster)

--- a/controllers/addoncontroller_legacyolm_test.go
+++ b/controllers/addoncontroller_legacyolm_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -504,7 +505,7 @@ var _ = Describe("Addoncontroller - legacy OLM deployment tests", func() {
 						}
 
 						BeforeEach(func() {
-							addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement)
+							addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement, "", "", nil)
 						})
 						AfterEach(func() {
 							cleanupAddonDeploymentConfig(addonDeploymentConfig, true)
@@ -608,7 +609,7 @@ var _ = Describe("Addoncontroller - legacy OLM deployment tests", func() {
 						},
 					}
 					BeforeEach(func() {
-						addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement)
+						addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement, "", "", nil)
 
 						// Update the managedclusteraddon before we create it to add the addondeploymentconfig
 						mcAddon.Spec.Configs = []addonv1alpha1.AddOnConfig{
@@ -684,7 +685,7 @@ var _ = Describe("Addoncontroller - legacy OLM deployment tests", func() {
 						},
 					}
 					BeforeEach(func() {
-						addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement)
+						addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement, "", "", nil)
 
 						// Update the managedclusteraddon before we create it to add the addondeploymentconfig
 						mcAddon.Spec.Configs = []addonv1alpha1.AddOnConfig{
@@ -769,7 +770,7 @@ var _ = Describe("Addoncontroller - legacy OLM deployment tests", func() {
 						},
 					}
 					BeforeEach(func() {
-						addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement)
+						addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement, "", "", nil)
 
 						// Update the managedclusteraddon before we create it to add the addondeploymentconfig
 						mcAddon.Spec.Configs = []addonv1alpha1.AddOnConfig{
@@ -866,7 +867,7 @@ var _ = Describe("Addoncontroller - legacy OLM deployment tests", func() {
 						},
 					}
 
-					defaultAddonDeploymentConfig = createAddonDeploymentConfig(defaultNodePlacement)
+					defaultAddonDeploymentConfig = createAddonDeploymentConfig(defaultNodePlacement, "", "", nil)
 
 					// Update the ClusterManagementAddOn before we create it to set a default deployment config
 					clusterManagementAddon.Spec.SupportedConfigs[0].DefaultConfig = &addonv1alpha1.ConfigReferent{
@@ -1077,7 +1078,7 @@ var _ = Describe("Addoncontroller - legacy OLM deployment tests", func() {
 						},
 					}
 					BeforeEach(func() {
-						addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement)
+						addonDeploymentConfig = createAddonDeploymentConfig(nodePlacement, "", "", nil)
 
 						// Update the managedclusteraddon before we create it to add the addondeploymentconfig
 						mcAddon.Spec.Configs = []addonv1alpha1.AddOnConfig{

--- a/controllers/helmutils/helmutils_test.go
+++ b/controllers/helmutils/helmutils_test.go
@@ -38,6 +38,28 @@ var _ = Describe("Helmutils", func() {
 		})
 	})
 
+	Context("Load embedded helm charts", func() {
+		// see the test suite BeforeSuite() for initing the volsync default img values with our test charts
+		It("Should have default volsync operand images loaded for stable-X.Y", func() {
+			defaultImageMap, err := helmutils.GetVolSyncDefaultImagesMap(controllers.DefaultHelmChartKey)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(defaultImageMap).NotTo(BeNil())
+
+			vsImage, ok := defaultImageMap[controllers.EnvVarVolSyncImageName]
+			Expect(ok).To(BeTrue())
+			Expect(vsImage).To(ContainSubstring("rhacm2-volsync-rhel"))
+
+			rbacProxyImage, ok := defaultImageMap[controllers.EnvVarRbacProxyImageName]
+			Expect(ok).To(BeTrue())
+			Expect(rbacProxyImage).To(ContainSubstring("ose-kube-rbac-proxy"))
+		})
+
+		It("Should not have other charts loaded", func() {
+			_, err := helmutils.GetEmbeddedChart("nothere")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Context("Rendering helm charts into objects", func() {
 		var testNamespace string
 		var clusterIsOpenShift bool

--- a/helmcharts/stable-0.12/images.yaml
+++ b/helmcharts/stable-0.12/images.yaml
@@ -1,0 +1,2 @@
+"OPERAND_IMAGE_VOLSYNC": "registry-proxy.engineering.redhat.com/rh-osbs/rhacm2-volsync-rhel8@sha256:a9b062f27b09ad8a42f7be2ee361baecc5856f66a83f7c4eb938a578b2713949" # v0.12.0-4
+"OPERAND_IMAGE_VOLSYNC_RBACPROXY": "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.15"

--- a/helmcharts/stable-0.12/volsync/values.yaml
+++ b/helmcharts/stable-0.12/volsync/values.yaml
@@ -7,34 +7,36 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # Directly specifies the SHA hash of the container image to deploy
-  image: "registry-proxy.engineering.redhat.com/rh-osbs/rhacm2-volsync-rhel8@sha256:a9b062f27b09ad8a42f7be2ee361baecc5856f66a83f7c4eb938a578b2713949" # v0.12.0-4
+  image: ""
 rclone:
   repository: quay.io/backube/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
-  image: "registry-proxy.engineering.redhat.com/rh-osbs/rhacm2-volsync-rhel8@sha256:a9b062f27b09ad8a42f7be2ee361baecc5856f66a83f7c4eb938a578b2713949" # v0.12.0-4
+  image: ""
 restic:
   repository: quay.io/backube/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
-  image: "registry-proxy.engineering.redhat.com/rh-osbs/rhacm2-volsync-rhel8@sha256:a9b062f27b09ad8a42f7be2ee361baecc5856f66a83f7c4eb938a578b2713949" # v0.12.0-4
+  image: ""
 rsync:
   repository: quay.io/backube/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
-  image: "registry-proxy.engineering.redhat.com/rh-osbs/rhacm2-volsync-rhel8@sha256:a9b062f27b09ad8a42f7be2ee361baecc5856f66a83f7c4eb938a578b2713949" # v0.12.0-4
+  image: ""
 rsync-tls:
   repository: quay.io/backube/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
-  image: "registry-proxy.engineering.redhat.com/rh-osbs/rhacm2-volsync-rhel8@sha256:a9b062f27b09ad8a42f7be2ee361baecc5856f66a83f7c4eb938a578b2713949" # v0.12.0-4
+  image: ""
 syncthing:
   repository: quay.io/backube/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
-  image: "registry-proxy.engineering.redhat.com/rh-osbs/rhacm2-volsync-rhel8@sha256:a9b062f27b09ad8a42f7be2ee361baecc5856f66a83f7c4eb938a578b2713949" # v0.12.0-4
+  image: ""
 kube-rbac-proxy:
-  image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.15
+  repository: quay.io/brancz/kube-rbac-proxy
+  tag: "v0.18.1"
+  image: ""
 
 manageCRDs: true
 

--- a/main.go
+++ b/main.go
@@ -33,9 +33,8 @@ func main() {
 	command := newCommand()
 	fmt.Printf("VolSyncAddonController version: %s\n", command.Version)
 
-	embeddedHelmChartsDir := os.Getenv("EMBEDDED_CHARTS_DIR")
 	// Load local embedded helm charts - will be read in as a charts object
-	err := helmutils.InitEmbeddedCharts(embeddedHelmChartsDir)
+	err := helmutils.InitEmbeddedCharts("")
 	if err != nil {
 		fmt.Printf("error loading embedded chart: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
- Allow env vars for volsync so they can be overridden in common way (via addondeploymentconfig.spec.customizedVariables)
- env vars currently are:
  - OPERAND_IMAGE_VOLSYNC
  - OPERAND_IMAGE_VOLSYNC_RBACPROXY
- Make sure these are set by default - loading it in from an images.yaml file currently (in future they may come from acm operand images)
- When env vars are set, make sure all the correct args are passed in the volsync helm chart so movers use the correct image too
- Allow addondeploymentconfig.spec.registries to be used to override the image repo (source and mirror can be set to override source image repo for images with the mirror)