### PR TITLE
adding .github/renovate.json for konflux

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "addLabels": ["ok-to-test"],
+  "baseBranches": ["/(^main$)|(^release-2\\.(10|11|12|13)$)/"],
+  "rebaseWhen": "behind-base-branch",
+  "recreateWhen": "never",
+  "schedule": ["before 8am on tuesday and thursday"],
+  "timezone": "America/New_York"
+}


### PR DESCRIPTION
- uses main as base branch as well as older release-2.y branches
- does not include release-2.14 as main ffwds there