### PR TITLE
updates for envtest - use versions from go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Helper software versions
 GOLANGCI_VERSION := v1.60.3
-ENVTEST_K8S_VERSION = 1.30
+#ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
+ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
+#ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
+
 
 GO_LD_EXTRAFLAGS ?=
 
@@ -71,7 +75,7 @@ $(GOLANGCILINT): $(LOCALBIN)
 ENVTEST = $(LOCALBIN)/setup-envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: ginkgo
 GINKGO := $(LOCALBIN)/ginkgo

--- a/controllers/addoncontroller_test.go
+++ b/controllers/addoncontroller_test.go
@@ -1734,7 +1734,9 @@ var _ = Describe("Addon Status Update Tests", func() {
 							if statusCondition == nil {
 								return false
 							}
-							return statusCondition.Reason == "ProbeUnavailable"
+
+							return statusCondition.Reason == "ProbeUnavailable" &&
+								strings.Contains(statusCondition.Message, "readyReplicas")
 						}, timeout, interval).Should(BeTrue())
 
 						Expect(statusCondition.Reason).To(Equal("ProbeUnavailable"))
@@ -1791,7 +1793,8 @@ var _ = Describe("Addon Status Update Tests", func() {
 							if statusCondition == nil {
 								return false
 							}
-							return statusCondition.Reason == "ProbeUnavailable"
+							return statusCondition.Reason == "ProbeUnavailable" &&
+								strings.Contains(statusCondition.Message, "desiredNumberReplicas")
 						}, timeout, interval).Should(BeTrue())
 
 						logger.Info("#### status condition", "statusCondition", statusCondition)


### PR DESCRIPTION
- Update Makefile so envtest will use the version that matches up with the version we use for controller-runtime
- Update Makefile so envtest will use a k8s image that matches with the kube version we use with k8s.io/api