### PR TITLE
Golangci lint update

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 ---
+version: "2"
 linters:
   # Defaults are still enabled, see:
   #  https://golangci-lint.run/usage/linters/#enabled-by-default
@@ -6,23 +7,37 @@ linters:
   # Enable these specific additional linters to match what
   # sonar checks for
   enable:
-    - goimports
-    - ineffassign
-    - misspell
-    - lll
-    - unparam
     - funlen
-
-linters-settings:
-  funlen:
-    #  Checks the number of lines in a function.
-    #  If lower than 0, disable the check.
-    #  Default: 60
-    # lines: 60
-    #  Checks the number of statements in a function.
-    #  If lower than 0, disable the check.
-    #  Default: 40
-    statements: -1
-    #  Ignore comments when counting lines.
-    #  Default false
-    ignore-comments: true
+    - lll
+    - misspell
+    - unparam
+  settings:
+    funlen:
+      statements: -1
+      ignore-comments: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - revive
+          - staticcheck
+        text: 'should not use dot imports'
+        source: . "github.com/onsi/(ginkgo/v2|gomega)"
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ARCH := $(shell go env GOARCH)
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Helper software versions
-GOLANGCI_VERSION := v1.60.3
+GOLANGCI_VERSION := v2.0.2
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)

--- a/controllers/helmutils/helmutils.go
+++ b/controllers/helmutils/helmutils.go
@@ -121,7 +121,7 @@ func GetVolSyncDefaultImagesMap(chartKey string) (map[string]string, error) {
 func GetEmbeddedChart(chartKey string) (*chart.Chart, error) {
 	loadedChart, ok := loadedChartsMap.Load(chartKey)
 	if !ok {
-		return nil, fmt.Errorf("Unable to find chart %s", chartKey)
+		return nil, fmt.Errorf("unable to find chart %s", chartKey)
 	}
 	return loadedChart.(*chart.Chart), nil
 }


### PR DESCRIPTION
- Update to use golangci-lint v2 (v2.0.2 to be exact)
- migrate the .golangci.yml
- fix new linting issues picked up by the linter