### PR TITLE
[release-2.12] konflux enable multi-arch on push pipeline only (#721)

### DIFF
--- a/.tekton/volsync-addon-controller-acm-212-push.yaml
+++ b/.tekton/volsync-addon-controller-acm-212-push.yaml
@@ -29,6 +29,12 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/release-acm-212/volsync-addon-controller-acm-212:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile.rhtap
   - name: path-context


### PR DESCRIPTION
(cherry picked from commit 9e0ad855592679659591cb26a12e5fff79e8c0dd)