### PR TITLE
update build-image-index konflux task sha

### DIFF
--- a/.tekton/volsync-addon-controller-acm-214-pull-request.yaml
+++ b/.tekton/volsync-addon-controller-acm-214-pull-request.yaml
@@ -277,7 +277,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3e90dde3edfeb7db874e0ef0e29890d826a1ccd114b37eedda50ce625d0344a7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/volsync-addon-controller-acm-214-push.yaml
+++ b/.tekton/volsync-addon-controller-acm-214-push.yaml
@@ -298,7 +298,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3e90dde3edfeb7db874e0ef0e29890d826a1ccd114b37eedda50ce625d0344a7
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
update is needed to fix build-image-index task as the enterprise contract checks are failing due to sbom generation broken