### PR TITLE
renovate disable golang updates for .Z branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,21 @@
     "release-2.13",
     "release-2.14"
   ],
+  "packageRules": [
+    {
+      "baseBranchList": [
+        "release-2.10",
+        "release-2.11",
+        "release-2.12",
+        "release-2.13",
+        "release-2.14"
+      ],
+      "matchManagers": [
+        "gomod"
+      ],
+      "enabled": false
+    }
+  ],
   "rebaseWhen": "behind-base-branch",
   "prConcurrentLimit": 0,
   "timezone": "America/New_York",


### PR DESCRIPTION
- attempt to disable golang updates on older release branches (main/release-2.15 is the current)
- renovate will always do security updates, so security updates should still generate PRs, even to these branches