### PR TITLE
[Release 2.11] downstream dockerfile labels https://issues.redhat.com/browse/ACM-22882

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -27,8 +27,20 @@ RUN GO111MODULE=on go build -tags strictfipsruntime -a -o controller -ldflags "-
 # Final container
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
-#RUN microdnf -y --refresh update && \
-#    microdnf clean all
+# RUN microdnf -y --refresh update && \
+#     microdnf clean all
+
+LABEL \
+    name="volsync-addon-controller" \
+    com.redhat.component="volsync-addon-controller" \
+    description="An addon controller for Red Hat Advanced Cluster Management (ACM) that deploys the VolSync \
+    operator on managed clusters based on ManagedClusterAddOn custom resources (CRs)." \
+    io.k8s.description="An addon controller for Red Hat Advanced Cluster Management (ACM) that deploys the VolSync \
+    operator on managed clusters based on ManagedClusterAddOn custom resources (CRs)." \
+    summary="A controller addon for Red Hat ACM that deploys the VolSync operator \
+    on managed clusters using ManagedClusterAddOn CRs." \
+    io.k8s.display-name="Red Hat Advanced Cluster Management Volsync Addon Controller" \
+    io.openshift.tags="acm volsync-addon-controller"
 
 WORKDIR /
 COPY --from=builder /workspace/controller .


### PR DESCRIPTION
Needed for konflux builds in release-2.11.

For issue: https://issues.redhat.com/browse/ACM-22882