### PR TITLE
attempt to include version/commit in build for logging

### DIFF
--- a/.tekton/volsync-addon-controller-acm-215-pull-request.yaml
+++ b/.tekton/volsync-addon-controller-acm-215-pull-request.yaml
@@ -37,6 +37,10 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Dockerfile.rhtap
+  - name: build-args
+    value:
+    - "versionFromGit_arg=2.15"
+    - "commitFromGit_arg={{revision}}"
   - name: path-context
     value: .
   pipelineRef:

--- a/.tekton/volsync-addon-controller-acm-215-push.yaml
+++ b/.tekton/volsync-addon-controller-acm-215-push.yaml
@@ -37,6 +37,10 @@ spec:
     - linux/arm64
   - name: dockerfile
     value: Dockerfile.rhtap
+  - name: build-args
+    value:
+    - "versionFromGit_arg=2.15"
+    - "commitFromGit_arg={{revision}}"
   - name: path-context
     value: .
   pipelineRef:

--- a/main.go
+++ b/main.go
@@ -22,9 +22,11 @@ import (
 	"github.com/stolostron/volsync-addon-controller/controllers/helmutils"
 )
 
-var versionFromGit = "0.0.0"
-var commitFromGit = ""
-var embeddedChartsDir = controllers.DefaultEmbeddedChartsDir
+var (
+	versionFromGit    = "0.0.0"
+	commitFromGit     = ""
+	embeddedChartsDir = controllers.DefaultEmbeddedChartsDir
+)
 
 func main() {
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
@@ -35,6 +37,7 @@ func main() {
 
 	command := newCommand()
 	fmt.Printf("VolSyncAddonController version: %s\n", command.Version)
+	// The controllercmd builder will also print out the version info when we start it
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -54,11 +57,7 @@ func newCommand() *cobra.Command {
 		},
 	}
 
-	if v := getVersion().String(); len(v) == 0 {
-		cmd.Version = "<unknown>"
-	} else {
-		cmd.Version = v
-	}
+	cmd.Version = getVersionAsString()
 
 	cmd.AddCommand(newControllerCommand())
 
@@ -120,4 +119,24 @@ func getVersion() version.Info {
 		GitCommit:  commitFromGit,
 		GitVersion: versionFromGit,
 	}
+}
+
+// Format version.Info as string
+func getVersionAsString() string {
+	versionAsString := "<unknown>"
+
+	v := getVersion()
+
+	if v.String() != "" {
+		versionAsString = v.String()
+	}
+
+	if gitCommit := v.GitCommit; gitCommit != "" {
+		if len(gitCommit) > 7 {
+			gitCommit = gitCommit[:7]
+		}
+		versionAsString = versionAsString + "-" + gitCommit
+	}
+
+	return versionAsString
 }


### PR DESCRIPTION
Update for konflux build for main/release-2.15 so at startup volsync-addon-controller can show the version being used.  Was previously set in CPaaS builds, but has been unset for konflux.

Note this sets the version to 2.15, would be nice to have the full x.y.z version, but I don't want to have to manage it in the .tekton files, so I've left just X.Y.  Would be nice to eventually use/set CI_VERSION  if we have a good way to get this (in the pipeline or a task) automatically - mce team has been looking into this.