### PR TITLE
[main] chore(KONFLUX-6210): fix and set name and cpe label for volsync-addon-controller-acm-215

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -31,7 +31,8 @@ FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:2f06ae0e6d3d9c4f610d32c48
 #     microdnf clean all
 
 LABEL \
-    name="volsync-addon-controller" \
+    name="rhacm2/acm-volsync-addon-controller-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.15::el9" \
     com.redhat.component="volsync-addon-controller" \
     description="An addon controller for Red Hat Advanced Cluster Management (ACM) that deploys the VolSync \
     operator on managed clusters based on ManagedClusterAddOn custom resources (CRs)." \


### PR DESCRIPTION
## Summary
Update labels in Dockerfile.rhtap for volsync-addon-controller to include the cpe label for ACM 2.15.

This change ensures proper security scanning integration and follows the established pattern from other ACM components.

### Changes
- Changed name label from `volsync-addon-controller` to `rhacm2/acm-volsync-addon-controller-rhel9`
- Added cpe label: `cpe:/a:redhat:acm:2.15::el9`

Based on original PR: #1096

Created-by: Claude AI