### PR TITLE
disable non-security renovate go updates for 2.17

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,8 @@
           "release-2.13",
           "release-2.14",
           "release-2.15",
-          "release-2.16"
+          "release-2.16",
+          "release-2.17"
         ],
         "matchManagers": [
           "gomod"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to include additional release branches for dependency management automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->