### PR TITLE
[release-2.17] CVE-2026-18874 — validate MCAO annotation overrides before YAML render - ACM-39790

### DIFF
--- a/controllers/addoncontroller.go
+++ b/controllers/addoncontroller.go
@@ -2,7 +2,10 @@ package controllers
 
 import (
 	"embed"
+	"regexp"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -192,15 +195,28 @@ func subHealthChecker(fieldResults []agent.FieldResult,
 	return mh.subHealthCheck(fieldResults)
 }
 
+// annotationOverrideValueRE constrains annotation override values to a charset
+// that is safe to render as a bare YAML scalar. The values returned by
+// getAnnotationOverrideOrDefault are interpolated into manifest templates via
+// text/template (no YAML-aware escaping), so newlines, colons, quotes or other
+// YAML metacharacters in the annotation would let the caller inject additional
+// fields into the rendered manifest.
+var annotationOverrideValueRE = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+
 func getAnnotationOverrideOrDefault(addon *addonapiv1alpha1.ManagedClusterAddOn,
 	annotationName, defaultValue string,
 ) string {
 	// Allow to be overridden with an annotation
 	annotationOverride, ok := addon.Annotations[annotationName]
-	if ok && annotationOverride != "" {
-		return annotationOverride
+	if !ok || annotationOverride == "" {
+		return defaultValue
 	}
-	return defaultValue
+	if !annotationOverrideValueRE.MatchString(annotationOverride) {
+		klog.InfoS("Ignoring ManagedClusterAddOn annotation override with invalid value",
+			"annotation", annotationName, "addonNamespace", addon.GetNamespace())
+		return defaultValue
+	}
+	return annotationOverride
 }
 
 func isOpenShift(cluster *clusterv1.ManagedCluster) bool {

--- a/controllers/addoncontroller_legacyolm_test.go
+++ b/controllers/addoncontroller_legacyolm_test.go
@@ -319,6 +319,21 @@ var _ = Describe("Addoncontroller - legacy OLM deployment tests", func() {
 							controllers.DefaultCatalogSourceNamespace))
 					})
 				})
+
+				Context("When an annotation override contains YAML metacharacters", func() {
+					BeforeEach(func() {
+						// Annotation values are rendered into the Subscription manifest via
+						// text/template; an embedded newline would otherwise let the
+						// annotation author inject sibling spec fields (e.g. spec.config).
+						mcAddon.Annotations[controllers.AnnotationStartingCSVOverride] =
+							"volsync-product.v0.16.0\n  config:\n    env:\n    - name: X\n      value: y"
+					})
+					It("Should ignore the invalid annotation value and use the default", func() {
+						Expect(operatorSubscription.Spec.StartingCSV).To(Equal(controllers.DefaultStartingCSV))
+						// The enclosing JustBeforeEach already asserts Spec.Config == nil,
+						// proving no spec.config block was injected into the rendered YAML.
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
The operator-subscription-* annotation values returned by getAnnotationOverrideOrDefault are interpolated into manifests/operator/operator-subscription.yaml via Go text/template as bare unquoted scalars. An annotation value containing a newline lets a hub user with only namespaced `patch managedclusteraddons` inject sibling fields (e.g. spec.config.env) into the rendered Subscription, which is then applied on the spoke as cluster-admin via ManifestWork. Constrain override values to [A-Za-z0-9._-]{1,128} — sufficient for every legitimate channel / CSV / catalog / approval value — and fall back to the compiled-in default with a log line when the value does not match.


Fixes: https://redhat.atlassian.net/browse/ACM-39790