### PR TITLE
backport: CVE-2026-18874 — validate MCAO annotation overrides before YAML render - ACM-39785

### DIFF
--- a/controllers/addoncontroller.go
+++ b/controllers/addoncontroller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/openshift/library-go/pkg/assets"
@@ -275,14 +276,27 @@ func getStartingCSV(addon *addonapiv1alpha1.ManagedClusterAddOn) string {
 	return getAnnotationOverrideOrDefault(addon, AnnotationStartingCSVOverride, DefaultStartingCSV)
 }
 
+// annotationOverrideValueRE constrains annotation override values to a charset
+// that is safe to render as a bare YAML scalar. The values returned by
+// getAnnotationOverrideOrDefault are interpolated into manifest templates via
+// text/template (no YAML-aware escaping), so newlines, colons, quotes or other
+// YAML metacharacters in the annotation would let the caller inject additional
+// fields into the rendered manifest.
+var annotationOverrideValueRE = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+
 func getAnnotationOverrideOrDefault(addon *addonapiv1alpha1.ManagedClusterAddOn,
 	annotationName, defaultValue string) string {
 	// Allow to be overridden with an annotation
 	annotationOverride, ok := addon.Annotations[annotationName]
-	if ok && annotationOverride != "" {
-		return annotationOverride
+	if !ok || annotationOverride == "" {
+		return defaultValue
 	}
-	return defaultValue
+	if !annotationOverrideValueRE.MatchString(annotationOverride) {
+		klog.InfoS("Ignoring ManagedClusterAddOn annotation override with invalid value",
+			"annotation", annotationName, "addonNamespace", addon.GetNamespace())
+		return defaultValue
+	}
+	return annotationOverride
 }
 
 func clusterSupportsAddonInstall(cluster *clusterv1.ManagedCluster) bool {

--- a/controllers/addoncontroller_test.go
+++ b/controllers/addoncontroller_test.go
@@ -331,6 +331,20 @@ var _ = Describe("Addoncontroller", func() {
 							controllers.DefaultCatalogSourceNamespace))
 					})
 				})
+
+				Context("When an annotation override contains YAML metacharacters", func() {
+					BeforeEach(func() {
+						// Annotation values are rendered into the Subscription manifest via
+						// text/template; an embedded newline would otherwise let the
+						// annotation author inject sibling spec fields (e.g. spec.config).
+						mcAddon.Annotations = map[string]string{
+							controllers.AnnotationStartingCSVOverride: "volsync-product.v0.10.0\n  config:\n    env:\n    - name: X\n      value: y",
+						}
+					})
+					It("Should ignore the invalid annotation value and use the default", func() {
+						Expect(operatorSubscription.Spec.StartingCSV).To(Equal(controllers.DefaultStartingCSV))
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
Cherry-picked from `da25480c9ef` (stolostron/release-2.17).

The `operator-subscription-*` annotation values returned by
`getAnnotationOverrideOrDefault` are interpolated into
`manifests/operator-subscription.yaml` via Go `text/template` as
bare unquoted scalars. An annotation value containing a newline lets a
hub user with only namespaced `patch managedclusteraddons` inject
sibling fields (e.g. `spec.config.env`) into the rendered Subscription,
which is then applied on the spoke as cluster-admin via ManifestWork.

Constrain override values to `[A-Za-z0-9._-]{1,128}` — sufficient for
every legitimate channel / CSV / catalog / approval value — and fall
back to the compiled-in default with a log line when the value does
not match.

**Changes:**
- `controllers/addoncontroller.go` — add compiled `annotationOverrideValueRE` regex and rewrite `getAnnotationOverrideOrDefault` to validate and reject unsafe annotation values
- `controllers/addoncontroller_test.go` — add test case for YAML metacharacter injection via annotation override

Fixes: https://redhat.atlassian.net/browse/ACM-39785