### PR TITLE
use PQC base img: https://redhat.atlassian.net/browse/ACM-41571

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -28,7 +28,7 @@ ARG commitFromGit_arg="(unknown)"
 RUN GO111MODULE=on go build -tags strictfipsruntime -a -o controller -ldflags "-X main.versionFromGit=${versionFromGit_arg} -X main.commitFromGit=${commitFromGit_arg}" main.go
 
 # Final container
-FROM registry.redhat.io/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 # RUN microdnf -y --refresh update && \
 #     microdnf clean all


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container base image to a UBI 9 minimal image with post-quantum cryptography support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->