### PR TITLE
Branching update

### DIFF
--- a/.github/workflows/cron-update-volsync-helmcharts.yml
+++ b/.github/workflows/cron-update-volsync-helmcharts.yml
@@ -14,9 +14,14 @@ jobs:
       matrix:
         branches:
           #
-          # ACM 5.0 = VolSync 0.17
-          # NOTES: - ACM br main is ffwding to release-5.0 atm
+          # ACM 5.1 = VolSync 0.18 (v0.18 not being built yet, so leaving as 0.17 for the moment)
+          # NOTES: - ACM br main is ffwding to release-5.1 atm
           - ACM_BRANCH: "main"
+            VOLSYNC_BRANCH: "release-0.17" # VolSync release branch
+            ACM_VOLSYNC_HELMCHARTS_DIR: "stable-0.17" # this name matches the operator channel name
+          #
+          # ACM 5.0 = VolSync 0.17
+          - ACM_BRANCH: "release-5.0"
             VOLSYNC_BRANCH: "release-0.17" # VolSync release branch
             ACM_VOLSYNC_HELMCHARTS_DIR: "stable-0.17" # this name matches the operator channel name
           #

--- a/.tekton/volsync-addon-controller-acm-52-pull-request.yaml
+++ b/.tekton/volsync-addon-controller-acm-52-pull-request.yaml
@@ -1,0 +1,62 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/volsync-addon-controller?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "release-5.2")
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-acm-52
+    appstudio.openshift.io/component: volsync-addon-controller-acm-52
+    pipelines.appstudio.openshift.io/type: build
+  name: volsync-addon-controller-acm-52-on-pull-request
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/volsync-addon-controller-acm-52:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: Dockerfile.rhtap
+  - name: build-args
+    value:
+    - ACM_VERSION=5.1
+    - "commitFromGit_arg={{revision}}"
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-volsync-addon-controller-acm-52
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/volsync-addon-controller-acm-52-pull-request.yaml
+++ b/.tekton/volsync-addon-controller-acm-52-pull-request.yaml
@@ -40,7 +40,7 @@ spec:
     value: Dockerfile.rhtap
   - name: build-args
     value:
-    - ACM_VERSION=5.1
+    - ACM_VERSION=5.2
     - "commitFromGit_arg={{revision}}"
   - name: path-context
     value: .

--- a/.tekton/volsync-addon-controller-acm-52-push.yaml
+++ b/.tekton/volsync-addon-controller-acm-52-push.yaml
@@ -1,0 +1,70 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/volsync-addon-controller?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-5.2"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-acm-52
+    appstudio.openshift.io/component: volsync-addon-controller-acm-52
+    pipelines.appstudio.openshift.io/type: build
+  name: volsync-addon-controller-acm-52-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/volsync-addon-controller-acm-52:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: Dockerfile.rhtap
+  - name: build-args
+    value:
+    - ACM_VERSION=5.1
+    - "commitFromGit_arg={{revision}}"
+  - name: path-context
+    value: .
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-acm-52"
+  - name: slack-webhook-url-secret-name
+    value: "backup-team-slack-notification-secret"
+  - name: slack-webhook-url-secret-key
+    value: "backup-team"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-volsync-addon-controller-acm-52
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/volsync-addon-controller-acm-52-push.yaml
+++ b/.tekton/volsync-addon-controller-acm-52-push.yaml
@@ -40,7 +40,7 @@ spec:
     value: Dockerfile.rhtap
   - name: build-args
     value:
-    - ACM_VERSION=5.1
+    - ACM_VERSION=5.2
     - "commitFromGit_arg={{revision}}"
   - name: path-context
     value: .


### PR DESCRIPTION
main is now not ffwding to 5.0 anymore, but 5.1 instead.

Update the cron job updater so that release-5.0 is automatically kept in sync with the release-0.17 volsync helm charts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request and push build pipelines for the ACM 5.2 VolSync addon controller.
  * Enabled multi-platform image builds, revision-tagged publishing, and build notifications.
  * Added ACM 5.1 coverage to automated Helm chart updates while preserving ACM 5.0 release tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->